### PR TITLE
feat: 사용자 등록 및 로그인 기능 개선과 예외 처리 강화

### DIFF
--- a/backend/src/main/java/com/hbbank/backend/exception/DuplicateUserException.java
+++ b/backend/src/main/java/com/hbbank/backend/exception/DuplicateUserException.java
@@ -1,0 +1,13 @@
+package com.hbbank.backend.exception;
+
+public class DuplicateUserException extends RuntimeException {
+
+    public DuplicateUserException() {
+        super("사용자가 이미 존재합니다.");
+    }
+
+    public DuplicateUserException(String msg) {
+        super(msg);
+    }
+
+}

--- a/backend/src/main/java/com/hbbank/backend/repository/UserRepository.java
+++ b/backend/src/main/java/com/hbbank/backend/repository/UserRepository.java
@@ -15,7 +15,4 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByEmail(String email);
 
-    @Query("SELECT u FROM User u WHERE u.username = :username AND u.password = :password")
-    Optional<User> findByUsernameAndPassword(String username, String password);
-
 }

--- a/backend/src/main/java/com/hbbank/backend/service/UserService.java
+++ b/backend/src/main/java/com/hbbank/backend/service/UserService.java
@@ -4,6 +4,9 @@ import java.time.LocalDate;
 import java.util.Optional;
 import java.util.UUID;
 
+import com.hbbank.backend.exception.DuplicateUserException;
+import com.hbbank.backend.exception.InvalidPasswordException;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,63 +38,69 @@ public class UserService {
                 });
     }
 
-    public User regist(UserRegistDTO user) {
-        return userRepository.save(User.builder()
-                .address(user.getAddress())
-                .birth(user.getBirth())
-                .email(user.getEmail())
-                .name(user.getName())
-                .password(passwordEncoder.encode(user.getPassword()))
-                .phone(user.getPhone())
-                .username(user.getUsername())
-                .emailVerified(true)
-                .build()
-        );
+    public User register(UserRegistDTO user) {
+        try {
+            return userRepository.save(User.builder()
+                    .address(user.getAddress())
+                    .birth(user.getBirth())
+                    .email(user.getEmail())
+                    .name(user.getName())
+                    .password(passwordEncoder.encode(user.getPassword()))
+                    .phone(user.getPhone())
+                    .username(user.getUsername())
+                    .emailVerified(true)
+                    .build()
+            );
+        } catch (DataIntegrityViolationException e) {
+            throw new DuplicateUserException("사용자가 이미 존재합니다.");
+        }
     }
 
-    public Optional<User> login(LoginRequestDTO loginRequest) {
+    public User login(LoginRequestDTO loginRequest) {
         String username = loginRequest.getUsername();
         String password = loginRequest.getPassword();
 
         User user = userRepository.findByUsername(username)
-                .orElseThrow(()->{
+                .orElseThrow(() -> {
                     log.warn("로그인 실패 - 존재하지 않는 사용자: {}", username);
                     return new UserNotFoundException("사용자를 찾을 수 없습니다.");
                 });
 
         if (passwordEncoder.matches(password, user.getPassword())) {
-            return Optional.of(user);
+            return user;
         } else {
             log.warn("로그인 실패 - 비밀번호 불일치 (사용자명: {})", username);
-            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+            throw new InvalidPasswordException("비밀번호가 일치하지 않습니다.");
         }
     }
 
     public void completeEmailVerification(String email) {
-        userRepository.findByEmail(email)
-                .ifPresent(user -> userRepository.save(user));
+        userRepository.findByEmail(email).ifPresent(userRepository::save);
     }
 
     public User registOAuth2User(String email, String name) {
-        User user = User.builder()
-                .email(email)
-                .name(name)
-                .username(email.split("@")[0])
-                .password(passwordEncoder.encode(UUID.randomUUID().toString()))
-                .isOAuth2User(true)
-                .needAdditionalInfo(true)
-                .birth(LocalDate.of(1900, 1, 1))
-                .address("서울")
-                .phone("010-0000-0000")
-                .emailVerified(true)
-                .build();
-
-        return userRepository.save(user);
+        try {
+            return userRepository.save(User.builder()
+                    .email(email)
+                    .name(name)
+                    .username(email.split("@")[0])
+                    .password(passwordEncoder.encode(UUID.randomUUID().toString()))
+                    .isOAuth2User(true)
+                    .needAdditionalInfo(true)
+                    .birth(LocalDate.of(1900, 1, 1))
+                    .address("서울")
+                    .phone("010-0000-0000")
+                    .emailVerified(true)
+                    .build()
+            );
+        } catch (DataIntegrityViolationException e) {
+            throw new DuplicateUserException("이미 존재하는 사용자입니다.");
+        }
     }
 
     public User findByEmail(String email) {
         return userRepository.findByEmail(email)
-                .orElseThrow(()->{
+                .orElseThrow(() -> {
                     log.warn("사용자 조회 실패 - 사용자 Email: {}", email);
                     return new UserNotFoundException("사용자를 찾을 수 없습니다");
                 });
@@ -110,7 +119,10 @@ public class UserService {
                 dto.getAddress(),
                 dto.getPhone()
         );
-
-        return userRepository.save(user);
+        try {
+            return userRepository.save(user);
+        } catch (DataIntegrityViolationException e) {
+            throw new DuplicateUserException("이미 존재하는 사용자입니다.");
+        }
     }
 }


### PR DESCRIPTION
# feat: 사용자 등록 및 로그인 기능 개선과 예외 처리 강화

## 📝 작업 내용
- UserController와 UserService의 'regist' 메서드명을 'register'로 변경하여 명확성 개선
- 사용자 중복 등록 처리를 위한 DuplicateUserException 도입
- 로그인 메서드 반환 타입을 Optional에서 User로 변경하여 로직 단순화
- UserRepository에서 더 이상 사용하지 않는 findByUsernameAndPassword 쿼리 제거

## 🔍 주요 변경사항
- 사용자 등록 시 중복 확인 로직 강화
- 로그인 프로세스 개선 및 단순화
- 예외 처리 로직 개선으로 유지보수성 향상
- 레거시 코드 정리

## ✅ 체크리스트
- [x] 테스트 코드가 있다면 모든 테스트가 통과하나요?
- [x] 새로운 테스트를 추가했나요?
- [x] 기존 기능이 정상 동작하나요?
- [x] 코드 스타일을 맞췄나요?
- [x] 관련 문서를 업데이트했나요?

## 🤔 참고사항
- 사용자 관련 기능의 안정성과 유지보수성 향상에 중점을 둔 리팩토링
- 예외 처리 강화로 더 나은 에러 핸들링 구현
- 관련 이슈: #10 